### PR TITLE
Edits for metis_lm_img_calibrate and metis_n_img_calibrate

### DIFF
--- a/IMG_data_items.tex
+++ b/IMG_data_items.tex
@@ -537,3 +537,113 @@ Processing \ac{FITS} Keywords: & provided at \ac{PAE}\\
 \end{enumerate}
 \end{datastructdef}    
     
+
+\paragraph{\hyperref[dataitem:lm_sci_calibrated]{\RAW{LM_SCI_CALIBRATED}}}\label{dataitem:lm_sci_calibrated}
+
+\begin{recipedef}
+\textbf{\ac{FITS} file structure:}\\
+Name: & \hyperref[dataitem:lm_sci_calibrated]{\FITS{LM_SCI_CALIBRATED}}\\[0.3cm]
+Description: & LM band image with flux calibration, WC coordinate system and distorion information\\[0.3cm]
+\hyperref[fits:dpr.catg]{\FITS{DPR.CATG}}: & \FITS{CALIB}\\
+\hyperref[fits:dpr.tech]{\FITS{DPR.TECH}}: & \FITS{IMG} \\
+\hyperref[fits:dpr.type]{\FITS{DPR.TYPE}}: & \FITS{RAW} \\[0.3cm]
+OCA keywords: & \hyperref[fits:dpr.catg]{\FITS{DPR.CATG}},  \hyperref[fits:dpr.tech]{\FITS{DPR.TECH}},  \hyperref[fits:dpr.type]{\FITS{DPR.TYPE}},  \hyperref[fits:ins.opti3.name]{\FITS{INS.OPTI3.NAME}},  \hyperref[fits:ins.opti9.name]{\FITS{INS.OPTI9.NAME}},  \hyperref[fits:ins.opti10.name]{\FITS{INS.OPTI10.NAME}}\\
+\FITS{DO.CATG}: & \FITS{LM\_LSS_RSRF\_RAW}\\[0.3cm]
+Template: & \TPL{METIS_img_lm_cal_standard}\\
+            & \TPL{METIS_img_lm_*_obs_*}       \\
+Input for recipe: & \hyperref[rec:metis_lm_img_std_process]{\REC{metis_lm_img_std_process}}\\
+Processing \ac{FITS} Keywords: & provided at \ac{PAE}\\
+%Data item structure: & see \ref{drsstructure:lmrsrfraw}\\
+\end{recipedef}
+\paragraph{\hyperref[dataitem:lm_sci_calibrated]{\PROD{LM\_SCI\_CALIBRATED}}}\label{drsstructure:lm_sci_combined}
+\begin{datastructdef}
+\textbf{Corresponding \ac{CPL} structure:}
+\begin{enumerate}
+    \item \texttt{cpl\_propertylist * keywords: Primary keywords (\hyperref[fits:dpr.catg]{\FITS{DPR.CATG}},  \hyperref[fits:dpr.tech]{\FITS{DPR.TECH}},  \hyperref[fits:dpr.type]{\FITS{DPR.TYPE}},  \hyperref[fits:ins.opti3.name]{\FITS{INS.OPTI3.NAME}},  \hyperref[fits:ins.opti9.name]{\FITS{INS.OPTI9.NAME}},  \hyperref[fits:ins.opti10.name]{\FITS{INS.OPTI10.NAME}})}
+    \item \texttt{hdrl\_image * image: Single image}
+    \item \texttt{cpl\_propertylist * plistarray[]: Extension keywords}
+\end{enumerate}
+\end{datastructdef}    
+    
+\paragraph{\hyperref[dataitem:n_sci_calibrated]{\RAW{N_SCI_CALIBRATED}}}\label{dataitem:n_sci_calibrated}
+
+
+\begin{recipedef}
+\textbf{\ac{FITS} file structure:}\\
+Name: & \hyperref[dataitem:n_sci_calibrated]{\FITS{N_SCI_CALIBRATED}}\\[0.3cm]
+Description: & N band image with flux calibration and distorion information\\[0.3cm]
+\hyperref[fits:dpr.catg]{\FITS{DPR.CATG}}: & \FITS{CALIB}\\
+\hyperref[fits:dpr.tech]{\FITS{DPR.TECH}}: & \FITS{IMG} \\
+\hyperref[fits:dpr.type]{\FITS{DPR.TYPE}}: & \FITS{RAW} \\[0.3cm]
+OCA keywords: & \hyperref[fits:dpr.catg]{\FITS{DPR.CATG}},  \hyperref[fits:dpr.tech]{\FITS{DPR.TECH}},  \hyperref[fits:dpr.type]{\FITS{DPR.TYPE}},  \hyperref[fits:ins.opti3.name]{\FITS{INS.OPTI3.NAME}},  \hyperref[fits:ins.opti9.name]{\FITS{INS.OPTI9.NAME}},  \hyperref[fits:ins.opti10.name]{\FITS{INS.OPTI10.NAME}}\\
+\FITS{DO.CATG}: & \FITS{N\_LSS_RSRF\_RAW}\\[0.3cm]
+Template: & \TPL{METIS_img_n_cal_standard}\\
+            & \TPL{METIS_img_n_*_obs_*}       \\
+Input for recipe: & \hyperref[rec:metis_n_img_std_process]{\REC{metis_n_img_std_process}}\\
+Processing \ac{FITS} Keywords: & provided at \ac{PAE}\\
+%Data item structure: & see \ref{drsstructure:nrsrfraw}\\
+\end{recipedef}
+\paragraph{\hyperref[dataitem:n_sci_calibrated]{\PROD{N\_SCI\_CALIBRATED}}}\label{drsstructure:n_sci_combined}
+\begin{datastructdef}
+\textbf{Corresponding \ac{CPL} structure:}
+\begin{enumerate}
+    \item \texttt{cpl\_propertylist * keywords: Primary keywords (\hyperref[fits:dpr.catg]{\FITS{DPR.CATG}},  \hyperref[fits:dpr.tech]{\FITS{DPR.TECH}},  \hyperref[fits:dpr.type]{\FITS{DPR.TYPE}},  \hyperref[fits:ins.opti3.name]{\FITS{INS.OPTI3.NAME}},  \hyperref[fits:ins.opti9.name]{\FITS{INS.OPTI9.NAME}},  \hyperref[fits:ins.opti10.name]{\FITS{INS.OPTI10.NAME}})}
+    \item \texttt{hdrl\_image * image: Single image}
+    \item \texttt{cpl\_propertylist * plistarray[]: Extension keywords}
+\end{enumerate}
+\end{datastructdef}    
+
+
+\paragraph{\hyperref[dataitem:lm_distortion_table]{\PROD{LM_DISTORTION_TABLE}}}\label{dataitem:lm_distortion_table}
+
+\begin{recipedef}
+\textbf{\ac{FITS TABLE} file structure:}\\
+Name: & \hyperref[dataitem:lm_distortion_table]{\FITS{LM\_DISTORTION\_TABLE}}\\[0.3cm]
+Description: & Table of distortion information\\[0.3cm]
+\hyperref[fits:dpr.catg]{\FITS{DPR.CATG}}: & \FITS{CALIB}\\
+\hyperref[fits:dpr.tech]{\FITS{DPR.TECH}}: & \FITS{IMG} \\
+\hyperref[fits:dpr.type]{\FITS{DPR.TYPE}}: & \FITS{RAW} \\[0.3cm]
+OCA keywords: & \hyperref[fits:dpr.catg]{\FITS{DPR.CATG}},  \hyperref[fits:dpr.tech]{\FITS{DPR.TECH}},  \hyperref[fits:dpr.type]{\FITS{DPR.TYPE}},  \hyperref[fits:ins.opti3.name]{\FITS{INS.OPTI3.NAME}},  \hyperref[fits:ins.opti9.name]{\FITS{INS.OPTI9.NAME}},  \hyperref[fits:ins.opti10.name]{\FITS{INS.OPTI10.NAME}}\\
+\FITS{DO.CATG}: & \FITS{LM\_LSS_RSRF\_RAW}\\[0.3cm]
+Template: & \TPL{??}\\
+Input for recipe: & \hyperref[rec:??]{\REC{??}}\\
+Processing \ac{FITS} Keywords: & provided at \ac{PAE}\\
+%Data item structure: & see \ref{drsstructure:lmrsrfraw}\\
+\end{recipedef}
+\paragraph{\hyperref[dataitem:lm_distortion_table]{\PROD{LM\_DISTORTION\_TABLE}}}\label{drsstructure:lm_distortion_table}
+\begin{datastructdef}
+\textbf{Corresponding \ac{CPL} structure:}
+\begin{enumerate}
+    \item \texttt{cpl\_propertylist * keywords: Primary keywords (\hyperref[fits:dpr.catg]{\FITS{DPR.CATG}},  \hyperref[fits:dpr.tech]{\FITS{DPR.TECH}},  \hyperref[fits:dpr.type]{\FITS{DPR.TYPE}},  \hyperref[fits:ins.opti3.name]{\FITS{INS.OPTI3.NAME}},  \hyperref[fits:ins.opti9.name]{\FITS{INS.OPTI9.NAME}},  \hyperref[fits:ins.opti10.name]{\FITS{INS.OPTI10.NAME}})}
+    \item \texttt{??}
+    \item \texttt{cpl\_propertylist * plistarray[]: Extension keywords}
+\end{enumerate}
+\end{datastructdef}    
+
+\paragraph{\hyperref[dataitem:n_distortion_table]{\PROD{N_DISTORTION_TABLE}}}\label{dataitem:n_distortion_table}
+
+\begin{recipedef}
+\textbf{\ac{FITS TABLE} file structure:}\\
+Name: & \hyperref[dataitem:n_distortion_table]{\FITS{N\_DISTORTION\_TABLE}}\\[0.3cm]
+Description: & Table of distortion information\\[0.3cm]
+\hyperref[fits:dpr.catg]{\FITS{DPR.CATG}}: & \FITS{CALIB}\\
+\hyperref[fits:dpr.tech]{\FITS{DPR.TECH}}: & \FITS{IMG} \\
+\hyperref[fits:dpr.type]{\FITS{DPR.TYPE}}: & \FITS{RAW} \\[0.3cm]
+OCA keywords: & \hyperref[fits:dpr.catg]{\FITS{DPR.CATG}},  \hyperref[fits:dpr.tech]{\FITS{DPR.TECH}},  \hyperref[fits:dpr.type]{\FITS{DPR.TYPE}},  \hyperref[fits:ins.opti3.name]{\FITS{INS.OPTI3.NAME}},  \hyperref[fits:ins.opti9.name]{\FITS{INS.OPTI9.NAME}},  \hyperref[fits:ins.opti10.name]{\FITS{INS.OPTI10.NAME}}\\
+\FITS{DO.CATG}: & \FITS{N\_LSS_RSRF\_RAW}\\[0.3cm]
+Template: & \TPL{??}\\
+Input for recipe: & \hyperref[rec:??]{\REC{??}}\\
+Processing \ac{FITS} Keywords: & provided at \ac{PAE}\\
+%Data item structure: & see \ref{drsstructure:nrsrfraw}\\
+\end{recipedef}
+\paragraph{\hyperref[dataitem:n_distortion_table]{\PROD{N\_DISTORTION\_TABLE}}}\label{drsstructure:n_distortion_table}
+\begin{datastructdef}
+\textbf{Corresponding \ac{CPL} structure:}
+\begin{enumerate}
+    \item \texttt{cpl\_propertylist * keywords: Primary keywords (\hyperref[fits:dpr.catg]{\FITS{DPR.CATG}},  \hyperref[fits:dpr.tech]{\FITS{DPR.TECH}},  \hyperref[fits:dpr.type]{\FITS{DPR.TYPE}},  \hyperref[fits:ins.opti3.name]{\FITS{INS.OPTI3.NAME}},  \hyperref[fits:ins.opti9.name]{\FITS{INS.OPTI9.NAME}},  \hyperref[fits:ins.opti10.name]{\FITS{INS.OPTI10.NAME}})}
+    \item \texttt{??}
+    \item \texttt{cpl\_propertylist * plistarray[]: Extension keywords}
+\end{enumerate}
+\end{datastructdef}    
+
+

--- a/IMG_drl_functions.tex
+++ b/IMG_drl_functions.tex
@@ -481,3 +481,87 @@ Quality assessment: & Through QC parameters \\
 Error conditions: & See \cite{DRLVT} (TBD). \\
 Unit tests: & See \cite{DRLVT} (TBD). \\
 \end{recipedef}
+
+
+\subsubsection{Convert LM Image to Physical Flux}\label{drl:lm_scale_image_flux}
+\begin{recipedef}
+Name: & \hyperref[drl:lm_scale_image_flux]{\DRL{lm_scale_image_flux}} \\
+Purpose: & Calculate the conversion between instrumental and physical flux units \\
+Used in recipes: & \hyperref[sssec:lm_img_calibrate]{\REC{metis_lm_img_cakubrate}}\\
+%Working remarks: & None \\
+%Function Parameters: & None \\
+Input: & \PROD{LM_SCI_BKG_SUBTRACTED}\\
+         \PROD{FLUXCAL_TAB} \\
+Other inputs: & None \\
+QC outputs: & None\\
+%Output FITS files: & \PROD{LM_STD_COMBINED} \\
+Outputs: & \texttt{cpl\_error\_code} \\
+General description: & Convert instrumental flux to ph/s \\
+Mathematical description: & See Section~\ref{sssec:lm_img_lm_calibrate} \\
+Quality assessment: & Through QC parameters \\
+Error conditions: & See \cite{DRLVT} (TBD). \\
+Unit tests: & See \cite{DRLVT} (TBD). \\
+\end{recipedef}
+
+
+
+\subsubsection{Add LM Calibration Information to Header}\label{drl:lm_update_header_distortion}
+\begin{recipedef}
+Name: & \hyperref[drl:lm_update_header_distortion]{\DRL{lm_update_header_distortion}} \\
+Purpose: & Update the FITS header with calibration data (WCS, distortion, units)  \\
+Used in recipes: & \hyperref[sssec:lm_img_calibrate]{\REC{metis_lm_img_calibrate}}\\
+%Working remarks: & None \\
+%Function Parameters: & None \\
+Input: &   \PROD{LM_SCI_BKG_SUBTRACTED}\\
+       &   \PROD{LM_DISTORTION_TABLE}\\
+QC outputs: & None \\
+Output FITS files: & \PROD{LM_SCI_CALIBRATED} \\
+Outputs: & \texttt{cpl\_error\_code} \\
+General description: & Add disortion, WCS and BUNIT information to FITS header \\
+Mathematical description: & See Section~\ref{sssec:lm_img_calibrate} \\
+Quality assessment: & None \\
+Error conditions: & See \cite{DRLVT} (TBD). \\
+Unit tests: & See \cite{DRLVT} (TBD). \\
+\end{recipedef}
+
+
+\subsubsection{Convert N Image to Physical Flux}\label{drl:n_scale_image_flux}
+\begin{recipedef}
+Name: & \hyperref[drl:n_scale_image_flux]{\DRL{n_scale_image_flux}} \\
+Purpose: & Calculate the conversion between instrumental and physical flux units \\
+Used in recipes: & \hyperref[sssec:n_img_calibrate]{\REC{metis_n_img_cakubrate}}\\
+%Working remarks: & None \\
+%Function Parameters: & None \\
+Input: & \PROD{N_SCI_BKG_SUBTRACTED}\\
+         \PROD{FLUXCAL_TAB} \\
+Other inputs: & None \\
+QC outputs: & None\\
+%Output FITS files: & \PROD{N_STD_COMBINED} \\
+Outputs: & \texttt{cpl\_error\_code} \\
+General description: & Convert instrumental flux to ph/s \\
+Mathematical description: & See Section~\ref{sssec:n_img_n_calibrate} \\
+Quality assessment: & Through QC parameters \\
+Error conditions: & See \cite{DRLVT} (TBD). \\
+Unit tests: & See \cite{DRLVT} (TBD). \\
+\end{recipedef}
+
+
+
+\subsubsection{Add N Calibration Information to Header}\label{drl:n_update_header_distortion}
+\begin{recipedef}
+Name: & \hyperref[drl:n_update_header_distortion]{\DRL{n_update_header_distortion}} \\
+Purpose: & Update the FITS header with calibration data (WCS, distortion, units)  \\
+Used in recipes: & \hyperref[sssec:n_img_calibrate]{\REC{metis_n_img_calibrate}}\\
+%Working remarks: & None \\
+%Function Parameters: & None \\
+Input: &   \PROD{N_SCI_BKG_SUBTRACTED}\\
+       &   \PROD{N_DISTORTION_TABLE}\\
+QC outputs: & None \\
+Output FITS files: & \PROD{N_SCI_CALIBRATED} \\
+Outputs: & \texttt{cpl\_error\_code} \\
+General description: & Add disortion and BUNIT information to FITS header \\
+Mathematical description: & See Section~\ref{sssec:n_img_calibrate} \\
+Quality assessment: & None \\
+Error conditions: & See \cite{DRLVT} (TBD). \\
+Unit tests: & See \cite{DRLVT} (TBD). \\
+\end{recipedef}

--- a/Recipes_Imaging_LM.tex
+++ b/Recipes_Imaging_LM.tex
@@ -280,7 +280,7 @@ QC parameter will include estimates of the sensitivity for the
 detection of point sources and surface brightness sensitivity
 following \cite{visir_manual}.
 
-\begin{recipedef}\label{rec:lm_img_photstd}
+\begin{recipedef}\label{rec:metis_lm_img_std_process}
   Name:                & \REC{metis_lm_img_std_process}                                               \\
   Purpose:             & Determine conversion factor between detector counts and physical source flux \\
   Type:                & Calibration                                                                  \\
@@ -351,19 +351,21 @@ higher-order polynomial distortion coefficients is written to the FITS
 header. The images are not resampled by this recipe, this is left to
 \REC{metis_lm_img_sci_postprocess}.
 
-\begin{recipedef}
+
+
+\begin{recipedef}\label{rec:metis_lm_img_calibrate}
   Name:              & \REC{metis_lm_img_calibrate}                     \\
   Purpose:           & Convert science images to physical units         \\
                      & Add distortion information                       \\
   Type:              & Calibration                                      \\
-  Templates          &                                                  \\
-  Input data:        & \CODE{LM_SCI_BKG_SUBTRACTED}                     \\
-                     & \CODE{FLUXCAL_TAB}                               \\
-                     & \CODE{LM_DISTORTION_TABLE}                       \\
+  Templates          & ??                                                 \\
+  Input data:        & \PROD{LM_SCI_BKG_SUBTRACTED}                     \\
+                     & \PROD{FLUXCAL_TAB}                               \\
+                     & \PROD{LM_DISTORTION_TABLE}                       \\
   Matched keywords:  & Filter ID                                        \\
   Parameters:        & None (TBD)                                       \\
-  Algorithm:         & Scale image data to ph/s                         \\
-                     & Add header information (\FITS{BUNIT}, WCS, etc.) \\
+  Algorithm:         & call \REC{lm_scale_image_flux} to Scale image data to ph/s \\
+                     & call \REC{lm_add_header_distortion} to add header information (\FITS{BUNIT}, WCS, etc.) \\
   Output data:       & \PROD{LM_SCI_CALIBRATED}                         \\
   QC1 parameters:    & None                                             \\
   hdrl functions:    & \CODE{hdrl_imagelist_mult_scalar}                \\
@@ -371,12 +373,12 @@ header. The images are not resampled by this recipe, this is left to
 
 \begin{figure}[hb]
   \centering
-  % \includegraphics[width=0.6\textwidth]{metis_lm_img_std_process}
-  \resizebox{0.6\textwidth}{0.1\textwidth}{\TODO{\fbox{Figure to be done}}}
-  \caption[Recipe: \REC{metis_lm_img_std_process}]{\REC{metis_lm_img_calibrate} --
-    convert images to physical flux units}
+  \includegraphics[width=0.6\textwidth]{lm_img_calibrate}
+  \caption[Recipe: \REC{metis_lm_img_calibrate}]{\REC{metis_lm_img_calibrate} --
+    Convert images to physical flux units and update FITS header}
   \label{fig:metis_lm_img_calibrate}
 \end{figure}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \clearpage

--- a/Recipes_Imaging_N.tex
+++ b/Recipes_Imaging_N.tex
@@ -215,29 +215,28 @@ values are in units of photons per second per centimetre squared. The
 header receives the keyword \FITS{BUNIT} with value %
 \CODE{'photon.s**(-1).cm**(-2)'}.
 
-\begin{recipedef}
+\begin{recipedef}\label{rec:metis_n_img_calibrate}
   Name:              & \REC{metis_n_img_calibrate}                      \\
   Purpose:           & Convert science image to physical units          \\
                      & Add distortion information                       \\
   Type:              & Calibration                                      \\
   Templates:         &                                                  \\
-  Input data:        & \CODE{N_SCI_BKG_SUBTRACTED}                      \\
-                     & \CODE{FLUXCAL_TAB}                               \\
-                     & \CODE{N_DISTORTION_TABLE}                        \\
+  Input data:        & \PROD{N_SCI_BKG_SUBTRACTED}                      \\
+                     & \PROD{FLUXCAL_TAB}                               \\
+                     & \PROD{N_DISTORTION_TABLE}                        \\
   Matched keywords:  & Filter ID                                        \\
   Parameters:        & TBD                                              \\
-  Algorithm:         & Scale image data to ph/s                         \\
-                     & Add header information (\FITS{BUNIT}, WCS, etc.) \\
+  Algorithm:         & call \REC{n_scale_image_flux} to Scale image data to ph/s \\
+                     & call \REC{n_add_header_distortion} to add header information (\FITS{BUNIT}, etc.)\\
   Output data:       & \PROD{N_SCI_CALIBRATED}                          \\
   QC1 parameters:    & None                                             \\
 \end{recipedef}
 
 \begin{figure}[hb]
   \centering
-  % \includegraphics[width=0.6\textwidth]{metis_n_img_std_process}
-  \resizebox{0.6\textwidth}{0.1\textwidth}{\TODO{\fbox{Figure to be done}}}
+   \includegraphics[width=0.6\textwidth]{n_img_std_process}
   \caption[Recipe: \REC{metis_n_img_calibrate}]{\REC{metis_n_img_calibrate} --
-    convert image to physical flux units}
+    convert image to physical flux units and update FITS header}
   \label{fig:metis_n_img_calibrate}
 \end{figure}
 


### PR DESCRIPTION
Note: this includes both the LM and N edits, as they were very similar, and fairly straightforward. 

Added functions
  lm_scale_image_flux
  n_scale_image_flux
  lm_add_header_distortion
  n_add_header_distortion

Added Datatypes
  LM_SCI_CALIBRATED
  N_SCI_CALIBRATED
  LM_DISTORTION_TABLE
  N_DISTORTION_TABLE

No QC paramters are needed for these routines.