### PR TITLE
Make boxes smaller

### DIFF
--- a/METIS_DRLD.tex
+++ b/METIS_DRLD.tex
@@ -254,7 +254,7 @@
 \newenvironment{datastructdef}
 {% begin code
   \begin{tcolorbox}[breakable,enhanced jigsaw]%
-    \begin{longtable}{p{\hsize}}}
+    \begin{longtable}{p{0.97\hsize}}}
       {% end code
     \end{longtable}%
   \end{tcolorbox}}


### PR DESCRIPTION
This makes the `recipedef` and `datastructuredef` boxes smaller. This removes resp. 355 and 80 overflow warnings.