### PR TITLE
Use \input instead of \include

### DIFF
--- a/11_0-critical_algorithms.tex
+++ b/11_0-critical_algorithms.tex
@@ -268,7 +268,7 @@ might disturb the cross correlation.\\
 
 \subsubsection{IFU Wavelength calibration and distortion correction}\label{ssec:criticalwavelengthanddistortionifu}
 \TODO{Should this be moved to Appendix and replaced by short summary here?}
-\include{CritAlgo_IFUdist}
+\input{CritAlgo_IFUdist}
 
 \subsection{Telluric correction}\label{ssec:criticaltelluriccorrection}
 Telluric correction, i.e. the removal of absorption features arising in the Earth's atmosphere, is a critical issue as the imprint of molecular species present in our air may vary on different timescales down to minutes due to changes in their composition and their amount. In particular the \ac{MIR} range is affected (see App~\ref{app:atmo_trans}).\\

--- a/METIS_DRLD.tex
+++ b/METIS_DRLD.tex
@@ -409,7 +409,7 @@
 \setlength{\glsdescwidth}{0.8\textwidth}
 
 % === Headers for notebook rendering ==========================================
-\include{JuPyter_header}
+\input{JuPyter_header}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
@@ -506,7 +506,7 @@ presented for \ac{PDR} and supersedes that document for \ac{FDR}.
 
 The following table lists the pipeline requirements and provides links to Polarion and the relevant place in this document.
 
-\include{Requirements}
+\input{Requirements}
 
 \clearpage
 


### PR DESCRIPTION
It is generally better to use `\input` rather than `\include`. `\input` just adds the contents from the relevant tex file into the source, while `\include` also adds a `\clearpage` or something.

I'll just merge this in, because that will remove some of the 'yellow warnings' on overleaf. Tagging you @ivh for reference.  