### PR TITLE
Generate figures from tikz in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,12 @@ METIS_DRLD.pdf: \
 
 all: METIS_DRLD.pdf
 
+clean_tikz: clean
+	# Ensure the tikz files are newer than the pdfs in the figures directory.
+	# Not part of clean itself, because different texlive versions might
+	# generate different figures, and we don't want people to have to deal
+	# with that.
+	touch tikz/*
+
 clean:
-	rm -f *.out *.aux *.log *.lof *.bbl *.bcf *.run.xml *.toc *.blg *.lot $(figures_from_tikz) METIS_DRLD.pdf
+	rm -f *.out *.aux *.log *.lof *.bbl *.bcf *.run.xml *.toc *.blg *.lot METIS_DRLD.pdf


### PR DESCRIPTION
@sesquideus this is my attempt at adding support for generating figures from tikz in the Makefile.

However, it is incomplete, because I don't know how to generalize the rule, and I don't want to manually add 19 rules that are almost identical. Could you help me generalize the rule below:

```Makefile
figures/metis_det_dark.pdf: tikz/metis_det_dark.tex
	# SOURCE_DATE_EPOCH to make sure the files are reproducible
	SOURCE_DATE_EPOCH=1830294000 TEXINPUTS=tikz: pdflatex -output-directory=figures metis_det_dark.tex
```

Also, the `figures_from_tikz` variable(?) could perhaps be generated automatically. Basically it contains all `.pdf` files in the figures directory for which there also is a  `.tex` file in the tikz directory. Could we get that automatically? It is currently generated with

```bash
for fn in tikz/*.tex ; do
    fnb=$(basename $fn .tex)
    fnp="figures/${fnb}.pdf"
    if [ -f $fnp ] ; then
        echo "$fnp"
    fi
done
```