### PR TITLE
Remove superfluous semicolons

### DIFF
--- a/tikz/metis_ifu_adi_cgrph.tex
+++ b/tikz/metis_ifu_adi_cgrph.tex
@@ -108,7 +108,7 @@
   \node (molecparams) [left=3.95cm of connectpers,yshift=0cm, params]{%
     Recipe parameters
   };
-  \draw [connection_arrow] (molecparams.east) -- (connectpers);%-- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);;
+  \draw [connection_arrow] (molecparams.east) -- (connectpers);%-- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);
 
   %\node (stdcat) [left=2cm of step5, external] {%
    % FLUXSTD\_CATALOG
@@ -122,17 +122,17 @@
 \node (incont1) [left=2cm of step6, yshift=0.8cm,calib]{%
     Coronagraphic throughput\\map/profile
   };
-\draw [connection_arrow] (incont1.east) -- ++(1, 0) -- ++(0., 0.8) -- ++(1, 0);;
+\draw [connection_arrow] (incont1.east) -- ++(1, 0) -- ++(0., 0.8) -- ++(1, 0);
 
 \node (incont2) [left=2cm of step6, yshift=-0.8cm,calproduct]{%
     Off-axis PSF reference cube
   };
-\draw [connection_arrow] (incont2.east) -- ++(1, 0) -- ++(0., -0.8) -- ++(1, 0);;
+\draw [connection_arrow] (incont2.east) -- ++(1, 0) -- ++(0., -0.8) -- ++(1, 0);
 
 \node (outcont1) [right=1.cm of step6, yshift=1cm,sciproduct]{%
     IFU\_cgrph\_SCI\_DEROTATED\_PSFSUB\_COADD
   };
-\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., -1) -- ++(0.5, 0);;
+\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., -1) -- ++(0.5, 0);
 
 \node (outcont2) [right=1.cm of step6, yshift=0cm,sciproduct]{%
     IFU\_cgrph\_SCI\_DEROTATED\_COADD
@@ -142,27 +142,27 @@
 \node (outcont3) [right=1.cm of step6, yshift=-1cm,sciproduct]{%
     IFU\_cgrph\_SCI\_COVERAGE
   };
-\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);;
+\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);
 
 \node (outcont4) [right=1.cm of step7, yshift=-1cm,sciproduct]{%
     IFU\_cgrph\_SCI\_CONTRAST\_RADPROF
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);
 
 \node (outcont5) [right=1.cm of step7, yshift=-2cm,sciproduct]{%
     IFU\_cgrph\_SCI\_CONTRAST\_ADI
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 2) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 2) -- ++(0.5, 0);
 
 \node (outcont6) [right=1.cm of step7, yshift=-3cm,sciproduct]{%
     IFU\_cgrph\_SCI\_THROUGHPUT
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 3) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 3) -- ++(0.5, 0);
 
 \node (outcont7) [right=1.cm of step7, yshift=-4cm,sciproduct]{%
     IFU\_cgrph\_SCI\_SNR
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 4) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 4) -- ++(0.5, 0);
 
 \node (reduced2) [right=1.5cm of step1, sciproduct]{%
     IFU\_cgrph\_CENTROID\_TAB

--- a/tikz/metis_img_adi_cgrph.tex
+++ b/tikz/metis_img_adi_cgrph.tex
@@ -107,7 +107,7 @@
   \node (molecparams) [right=3.cm of connectpers,yshift=0cm, sciproduct]{%
     [LM\textbackslash N]\_cgrph\_SCI\_CALIBRATED
   };
-  \draw [connection_arrow] (connectpers) -- (molecparams);%-- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);;
+  \draw [connection_arrow] (connectpers) -- (molecparams);%-- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);
 \node (molecparams2) [left=3.95cm of connectpers,yshift=0cm, params]{%
     Recipe parameters
   };
@@ -125,17 +125,17 @@
 \node (incont1) [left=2cm of step6, yshift=0.8cm,calib]{%
     Coronagraphic throughput\\ map/profile
   };
-\draw [connection_arrow] (incont1.east) -- ++(1, 0) -- ++(0., 0.8) -- ++(1, 0);;
+\draw [connection_arrow] (incont1.east) -- ++(1, 0) -- ++(0., 0.8) -- ++(1, 0);
 
 \node (incont2) [left=2cm of step6, yshift=-0.8cm,calproduct]{%
     Off-axis PSF reference
   };
-\draw [connection_arrow] (incont2.east) -- ++(1, 0) -- ++(0., -0.8) -- ++(1, 0);;
+\draw [connection_arrow] (incont2.east) -- ++(1, 0) -- ++(0., -0.8) -- ++(1, 0);
 
 \node (outcont1) [right=1.cm of step6, yshift=1cm,sciproduct]{%
     [LM/N]\_cgrph\_SCI\_DEROTATED\_PSFSUB\_COADD
   };
-\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., -1) -- ++(0.5, 0);;
+\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., -1) -- ++(0.5, 0);
 
 \node (outcont2) [right=1.cm of step6, yshift=0cm,sciproduct]{%
     [LM/N]\_cgrph\_SCI\_DEROTATED\_COADD
@@ -145,27 +145,27 @@
 \node (outcont3) [right=1.cm of step6, yshift=-1cm,sciproduct]{%
     [LM/N]\_cgrph\_SCI\_COVERAGE
   };
-\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);;
+\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);
 
 \node (outcont4) [right=1.cm of step7, yshift=-1cm,sciproduct]{%
     [LM/N]\_cgrph\_SCI\_CONTRAST\_RADPROF
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);
 
 \node (outcont5) [right=1.cm of step7, yshift=-2cm,sciproduct]{%
     [LM/N]\_cgrph\_SCI\_CONTRAST\_ADI
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 2) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 2) -- ++(0.5, 0);
 
 \node (outcont6) [right=1.cm of step7, yshift=-3cm,sciproduct]{%
     [LM/N]\_cgrph\_SCI\_THROUGHPUT
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 3) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 3) -- ++(0.5, 0);
 
 \node (outcont7) [right=1.cm of step7, yshift=-4cm,sciproduct]{%
     [LM/N]\_cgrph\_SCI\_SNR
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 4) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 4) -- ++(0.5, 0);
 
 \node (reduced2) [right=1.cm of step1, sciproduct]{%
     [LM/N]\_cgrph\_CENTROID\_TAB

--- a/tikz/metis_lm_adi_app.tex
+++ b/tikz/metis_lm_adi_app.tex
@@ -118,7 +118,7 @@
   \node (molecparams) [left=3.95cm of connectpers,yshift=0cm, params]{%
     Recipe parameters
   };
-  \draw [connection_arrow] (molecparams.east) -- (connectpers);%-- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);;
+  \draw [connection_arrow] (molecparams.east) -- (connectpers);%-- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);
 
   %\node (stdcat) [left=2cm of step5, external] {%
    % FLUXSTD\_CATALOG
@@ -132,17 +132,17 @@
 \node (incont1) [left=2cm of step6, yshift=0.8cm,calib]{%
     Coronagraphic throughput\\map/profile
   };
-\draw [connection_arrow] (incont1.east) -- ++(1, 0) -- ++(0., 0.8) -- ++(1, 0);;
+\draw [connection_arrow] (incont1.east) -- ++(1, 0) -- ++(0., 0.8) -- ++(1, 0);
 
 \node (incont2) [left=2cm of step6, yshift=-0.8cm,calproduct]{%
     Off-axis PSF reference
   };
-\draw [connection_arrow] (incont2.east) -- ++(1, 0) -- ++(0., -0.8) -- ++(1, 0);;
+\draw [connection_arrow] (incont2.east) -- ++(1, 0) -- ++(0., -0.8) -- ++(1, 0);
 
 \node (outcont1) [right=1.cm of step6, yshift=1cm,sciproduct]{%
     LM\_APP\_SCI\_DEROTATED\_PSFSUB\_COADD
   };
-\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., -1) -- ++(0.5, 0);;
+\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., -1) -- ++(0.5, 0);
 
 \node (outcont2) [right=1.cm of step6, yshift=0cm,sciproduct]{%
     LM\_APP\_SCI\_DEROTATED\_COADD
@@ -152,27 +152,27 @@
 \node (outcont3) [right=1.cm of step6, yshift=-1cm,sciproduct]{%
     LM\_APP\_SCI\_COVERAGE
   };
-\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);;
+\draw [connection_arrow] (step6.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);
 
 \node (outcont4) [right=1.cm of step7, yshift=-1cm,sciproduct]{%
     LM\_APP\_SCI\_CONTRAST\_RAW
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 1) -- ++(0.5, 0);
 
 \node (outcont5) [right=1.cm of step7, yshift=-2cm,sciproduct]{%
     LM\_APP\_SCI\_CONTRAST\_ADI
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 2) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 2) -- ++(0.5, 0);
 
 \node (outcont6) [right=1.cm of step7, yshift=-3cm,sciproduct]{%
     LM\_APP\_SCI\_THROUGHPUT
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 3) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 3) -- ++(0.5, 0);
 
 \node (outcont7) [right=1.cm of step7, yshift=-4cm,sciproduct]{%
     LM\_APP\_SCI\_SNR
   };
-\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 4) -- ++(0.5, 0);;
+\draw [connection_arrow] (step7.east) -- ++(0.5, 0) -- ++(0., 4) -- ++(0.5, 0);
 
 \node (reduced2) [right=1.5cm of step1, sciproduct]{%
     LM\_APP\_CENTROID\_TAB

--- a/tikz/metis_lm_img_calibrate.tex
+++ b/tikz/metis_lm_img_calibrate.tex
@@ -101,7 +101,7 @@
 %  \node (molecparams) [left=3.95cm of connectpers,yshift=-0.8cm, params]{%
 %    recipe parameters:\\INS.IMG.SETUP
 %  };
-%  \draw [connection_arrow] (molecparams.east) -- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);;
+%  \draw [connection_arrow] (molecparams.east) -- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);
 
   %\node (stdcat) [left=2cm of step5, external] {%
    % FLUXSTD\_CATALOG

--- a/tikz/metis_lm_img_std_process.tex
+++ b/tikz/metis_lm_img_std_process.tex
@@ -102,7 +102,7 @@
 %  \node (molecparams) [left=3.95cm of connectpers,yshift=-0.8cm, params]{%
 %    recipe parameters:\\INS.IMG.SETUP
 %  };
-%  \draw [connection_arrow] (molecparams.east) -- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);;
+%  \draw [connection_arrow] (molecparams.east) -- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);
 
   %\node (stdcat) [left=2cm of step5, external] {%
    % FLUXSTD\_CATALOG

--- a/tikz/metis_n_img_calibrate.tex
+++ b/tikz/metis_n_img_calibrate.tex
@@ -100,7 +100,7 @@
 %  \node (molecparams) [left=3.95cm of connectpers,yshift=-0.8cm, params]{%
 %    recipe parameters:\\INS.IMG.SETUP
 %  };
-%  \draw [connection_arrow] (molecparams.east) -- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);;
+%  \draw [connection_arrow] (molecparams.east) -- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);
 
   %\node (stdcat) [left=2cm of step5, external] {%
    % FLUXSTD\_CATALOG

--- a/tikz/metis_n_img_std_process.tex
+++ b/tikz/metis_n_img_std_process.tex
@@ -102,7 +102,7 @@
 %  \node (molecparams) [left=3.95cm of connectpers,yshift=-0.8cm, params]{%
 %    recipe parameters:\\INS.IMG.SETUP
 %  };
-%  \draw [connection_arrow] (molecparams.east) -- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);;
+%  \draw [connection_arrow] (molecparams.east) -- ++(0.25, 0) -- ++(0., -0.8) -- ++(3.75, 0);
 
   %\node (stdcat) [left=2cm of step5, external] {%
    % FLUXSTD\_CATALOG


### PR DESCRIPTION
Remove superfluous semicolons, as they cause this warning:

Missing character: There is no ; in font nullfont!