### PR TITLE
Update workflow action

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -28,7 +28,7 @@ jobs:
             git config --system --add safe.directory /github/workspace
           post_compile: mv METIS_DRLD.pdf "METIS_DRLD.$(date +'%Y%m%dT%H%M%S').${{ github.sha }}.pdf"
       - name: Upload PDF file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: METIS DRLD
           path: ./*.pdf


### PR DESCRIPTION
fixes "This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/"