### PR TITLE
Fail CI when consistency checks fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+  schedule:
+    # Run every day at 5:00 UTC
+    - cron: "0 5 * * *"
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -20,5 +24,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r codes/requirements.github_actions.txt
       - name: Run Pytest
-        continue-on-error: true
         run: pytest


### PR DESCRIPTION
Fail the CI when the consistency checks fail.

The database relies on the DRLD to construct the database schema, so the DRLD must be internally consistent.