### PR TITLE
Rename DPR.TECH PUP,M -> PUP,LM

### DIFF
--- a/APP_dpr_keywords.tex
+++ b/APP_dpr_keywords.tex
@@ -68,7 +68,7 @@
  SCIENCE   & IMAGE,N  & OBJECT         & N\_IMAGE\_SCI\_RAW      & \REC{metis_n_img_chopnod}       \\
  SCIENCE   & LSS,LM   & OBJECT         & LM\_LSS\_SCI\_RAW       & \REC{metis_LM_lss_sci}          \\
  SCIENCE   & LSS,N    & OBJECT         & N\_LSS\_SCI\_RAW        & \REC{metis_N_lss_sci}           \\
- TECHNICAL & PUP,M    & PUPIL          & LM\_PUPIL\_RAW         & \REC{metis_pupil_imaging}       \\
+ TECHNICAL & PUP,LM    & PUPIL          & LM\_PUPIL\_RAW         & \REC{metis_pupil_imaging}       \\
  TECHNICAL & PUP,N    & PUPIL          & N\_PUPIL\_RAW          & \REC{metis_pupil_imaging}       \\
  \hline
 \caption[DPR keywords table]{DPR keywords table}\label{tab:dpr_keywords}

--- a/IMG_data_items.tex
+++ b/IMG_data_items.tex
@@ -554,7 +554,7 @@ Processing \ac{FITS} Keywords: & provided at \ac{PAE}\\
 Name: & \RAW{LM_PUPIL_RAW}\\[0.3cm]
 Description: & Raw exposure of the pupil in LM image mode.\\[0.3cm]
 \FITS{DPR.CATG}: & \CODE{TECHNICAL}\\
-\FITS{DPR.TECH}: & \CODE{PUP,M} \\
+\FITS{DPR.TECH}: & \CODE{PUP,LM} \\
 \FITS{DPR.TYPE}: & \CODE{PUPIL} \\[0.3cm]
 OCA keywords: & \FITS{DPR.CATG},  \FITS{DPR.TECH},  \FITS{DPR.TYPE},  \FITS{INS.OPTI3.NAME},  \FITS{INS.OPTI9.NAME},  \FITS{INS.OPTI10.NAME}, \FITS{DRS.PUPIL}\\
 \FITS{DO.CATG}: & \CODE{LM_PUPIL_RAW}\\[0.3cm]


### PR DESCRIPTION
Fix PUP,LM value for DPR.TECH that I accidentally named PUP,M in 8a0d2cb6c48567883e3b2dd63a4fc646a4fe3eb0 . Now the DRLD is inconsistent with the data we produce in METIS_Simulations.

I'll just merge this